### PR TITLE
[data/restructure-signs] Reorganizes original dataset and verifies changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ env/
 .DS_Store
 .vscode/
 Data_Numpy_Arrays_RSL_UzSL/
+data/
 # C extensions
 *.so
 

--- a/dataset-prep/DATASET_STRUCTURE.md
+++ b/dataset-prep/DATASET_STRUCTURE.md
@@ -90,7 +90,8 @@ The dataset will be split into three subsets: **training**, **validation**, and 
 - **Repetitions per sign:** 38 signs × 52 repetitions, 12 signs × 51 repetitions
 - **File format:** NumPy arrays (`.npy`)
 - **Glossary:** "rep" = repetition
-
+- **Total repetition folders:** 2588 (38x52 + 12x51)
+- **Total `frame-XX.npy` files:** 82816
 
 **Reference** 
 Information learned from [HuggingFace - File names and splits](https://huggingface.co/docs/hub/datasets-file-names-and-splits)

--- a/dataset-prep/dataset-checks/01_check_frames.py
+++ b/dataset-prep/dataset-checks/01_check_frames.py
@@ -1,0 +1,49 @@
+"""
+(READ-ONLY file)
+Check that every repetition folder (rep-X) for each sign contains exactly 32 frame-XX.npy files.
+Reports any folders with missing or extra frames.
+"""
+
+import os
+from pathlib import Path
+
+# Path to the newly reorganized data folder
+DATA_DIR = Path('../../data')
+
+def check_frame_counts():
+    print("Checking frame counts in each repetition folder...\n")
+    
+    all_good = True
+    
+    for sign_dir in sorted(DATA_DIR.iterdir()):
+        if not sign_dir.is_dir():
+            continue
+        
+        print(f"Sign: {sign_dir.name}")
+        
+        for rep_dir in sorted(sign_dir.iterdir()):
+            if not rep_dir.is_dir() or not rep_dir.name.startswith('rep-'):
+                continue
+            
+            # Find all .npy files in this rep folder
+            npy_files = list(rep_dir.glob('frame-*.npy'))
+            count = len(npy_files)
+            
+            if count == 32:
+                print(f"  {rep_dir.name}: {count} frames -> OK")
+            else:
+                print(f"  {rep_dir.name}: {count} frames -> WARNING (expected 32)")
+                all_good = False
+    
+    print("\n" + "="*50)
+    if all_good:
+        print("All repetition folders have exactly 32 frames. Perfect!")
+    else:
+        print("Some repetition folders do NOT have exactly 32 frames.")
+
+if __name__ == "__main__":
+    if not DATA_DIR.exists():
+        print(f"Error: '{DATA_DIR}' folder not found.")
+    else:
+        check_frame_counts()
+

--- a/dataset-prep/dataset-checks/02_count_repetitions.py
+++ b/dataset-prep/dataset-checks/02_count_repetitions.py
@@ -1,0 +1,39 @@
+"""
+(READ-ONLY file)
+Counts and displays the total number of repetitions (rep-X folders) for each sign 
+in the 'data/' directory.
+
+Used for verifying that all 50 signs have the expected number of samples 
+"""
+
+from pathlib import Path
+
+DATA_DIR = Path('../../data')
+
+def count_repetitions_per_sign():
+    print("Counting repetitions for each sign...\n")
+    
+    if not DATA_DIR.exists():
+        print(f"Error: '{DATA_DIR}' folder not found!")
+        return
+    
+    total_reps = 0
+    
+    for sign_dir in sorted(DATA_DIR.iterdir()):
+        if not sign_dir.is_dir():
+            continue
+        
+        # Count folders that start with 'rep-'
+        rep_folders = [d for d in sign_dir.iterdir() if d.is_dir() and d.name.startswith('rep-')]
+        count = len(rep_folders)
+        
+        total_reps += count
+        print(f"{sign_dir.name}: {count} rep")
+    
+    print("\n" + "="*40)
+    print(f"Total number of repetition folders: {total_reps}")
+    print(f"Total number of signs: {len([d for d in DATA_DIR.iterdir() if d.is_dir()])}")
+
+if __name__ == "__main__":
+    count_repetitions_per_sign()
+

--- a/dataset-prep/step01_reorganize_dataset.py
+++ b/dataset-prep/step01_reorganize_dataset.py
@@ -1,0 +1,94 @@
+"""
+(WRITE-OUT file) USE WITH CAUTION!
+
+Safely reorganizes the UzSL landmark dataset by copying all repetition folders 
+from video-collector/Data_Numpy_Arrays_RSL_UzSL/signerXX/{sign}/landmarks/rep-XX/ 
+into a new clean structure: data/{sign}/rep-1/, rep-2/, ...
+
+- Copies only landmark data (original dataset remains untouched)
+- Merges repetitions from all 10 signers for each of the 50 signs
+- Renames folders sequentially (rep-1, rep-2, ...) to prevent conflicts
+- Ignores 'videos/' folders entirely
+- Prints progress and a summary of repetitions per sign
+"""
+
+import os
+import shutil
+from pathlib import Path
+
+# 50 default signs
+DEFAULT_SIGNS = ['assalomu_alaykum', 'bahor', 'birga', "bo'sh", 'bosh_kiyim', 'boshlanishi', 'bozor', 'eshik', 
+               'futbol', 'iltimos', 'internet', 'javob', 'jismoniy_tarbiya', 'karam', 'kartoshka', 
+               'kichik', 'kitob', "ko'prik", 'likopcha', 'maktab', 'mehmonxona', 'mehribon', 'metro', 
+               'musiqa', "o'simlik_yog'i", "o'ynash", 'ochish', 'ot', 'ovqat_tayyorlash', 
+               'oxiri', 'poezd', 'pomidor', 'qidirish', 'qish', "qo'ziqorin", 'qor', "qorong'i", 'quyon', 
+               'restoran', "sariyog'", 'shokolad', 'sovun', 'stakan', 'televizor', 'tosh', 'toza',
+               'turish', "yomg'ir", 'yopish', 'yordam_berish']
+
+
+def copy_and_reorganize_dataset():
+    # Original dataset location
+    base_path = Path('../video-collector/Data_Numpy_Arrays_RSL_UzSL')
+    
+    # New dataset location at the root level
+    target_base = Path('../data')
+    target_base.mkdir(exist_ok=True)
+    
+    # Counter to assign unique rep numbers per sign (starting from 1)
+    sign_rep_counter = {sign: 0 for sign in DEFAULT_SIGNS}
+    
+    total_copied = 0
+    
+    print("Starting safe copy and reorganization (original data will NOT be modified)...\n")
+    
+    # Loop through each signer (signer01 to signer10)
+    for signer_dir in sorted(base_path.iterdir()):
+        if not signer_dir.is_dir() or not signer_dir.name.startswith('signer'):
+            continue
+        
+        print(f"Processing {signer_dir.name}...")
+        
+        for sign_dir in signer_dir.iterdir():
+            if not sign_dir.is_dir() or sign_dir.name not in DEFAULT_SIGNS:
+                continue
+            
+            sign_name = sign_dir.name
+            landmarks_dir = sign_dir / 'landmarks'
+            
+            if not landmarks_dir.exists():
+                print(f"  Warning: No landmarks folder found for {sign_name} in {signer_dir.name}")
+                continue
+            
+            # Process each repetition folder inside landmarks/
+            for rep_dir in sorted(landmarks_dir.iterdir()):
+                if rep_dir.is_dir() and rep_dir.name.startswith('rep-'):
+                    # Increment and get new sequential name
+                    sign_rep_counter[sign_name] += 1
+                    new_rep_num = sign_rep_counter[sign_name]
+                    new_rep_name = f'rep-{new_rep_num}'
+                    
+                    # Create target directories
+                    target_sign_dir = target_base / sign_name
+                    target_sign_dir.mkdir(exist_ok=True)
+                    target_rep_dir = target_sign_dir / new_rep_name
+                    
+                    # COPY the entire repetition folder, much safer than shutil.move()
+                    shutil.copytree(str(rep_dir), str(target_rep_dir))
+                    total_copied += 1
+                    print(f"  Copied {rep_dir.relative_to(base_path.parent)} -> data/{sign_name}/{new_rep_name}/")
+    
+    print("\nCopy and reorganization completed safely!")
+    print(f"Total repetition folders copied: {total_copied}")
+    print(f"New dataset located at: {target_base.resolve()}")
+    
+    print("\nSummary per sign:")
+    for sign in sorted(DEFAULT_SIGNS):
+        count = sign_rep_counter[sign]
+        if count > 0:
+            print(f"  {sign}: {count} repetitions")
+        else:
+            print(f"  {sign}: 0 repetitions (warning: missing?)")
+
+if __name__ == "__main__":
+    copy_and_reorganize_dataset()
+


### PR DESCRIPTION
### Key Changes
- Added `step01_reorganize_dataset.py`:  
  Safely copies and merges all landmark repetition folders from the original multi-signer structure (`video-collector/Data_Numpy_Arrays_RSL_UzSL/signerXX/{sign}/landmarks/rep-XX/`) into a new top-level `data/{sign}/` directory.  
  - Renames repetition folders sequentially (`rep-1`, `rep-2`, ...) to avoid conflicts when combining data from 10 signers.  
  - Ignores and does not copy `videos/` folders.  
  - Original dataset remains completely untouched (copy-only operation).

- Added verification scripts inside of [`/dataset-prep/dataset-checks/`](https://github.com/00015775/uzslr-isolated-dynamic/tree/main/dataset-prep/dataset-checks):
  - `01_check_frames.py`: Confirms every `rep-X` folder contains exactly 32 `frame-XX.npy` files.
  - `02_count_repetitions.py`: Reports the total number of repetitions collected for each of the 50 signs.

### Resulting Structure
<pre>
.
└── data/
    └── {sign}/                      # e.g., assalomu_alaykum, bahor, birga, ...
         └── rep-{XX}/               # e.g., rep-0, rep-1, ..., rep-XX (repetitions)
             ├── frame-00.npy
             ├── frame-01.npy
             ├── ... 
             └── frame-XX.npy
</pre>


### Why This Change?
- Enables easy `train/val/test` splitting in the following steps.
- Ensures no data loss from name collisions.
- Provides quick validation tools to confirm dataset integrity.

Resolves #2